### PR TITLE
Improve dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,16 +68,9 @@ jobs:
   tests:
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4']
-        phpunit: ['7.*', '8.*', '9.*']
+        php: ['7.3', '7.4']
+        phpunit: ['9.*']
         dependency-version: ['prefer-lowest', 'prefer-stable']
-        exclude:
-            - phpunit: '8.*'
-              php: '7.1'
-            - phpunit: '9.*'
-              php: '7.1'
-            - phpunit: '9.*'
-              php: '7.2'
 
     runs-on: ubuntu-latest
     name: "PHP: ${{ matrix.php }}; PHPUnit: ${{ matrix.phpunit }}; Dependecies: ${{ matrix.dependency-version }}"
@@ -107,10 +100,6 @@ jobs:
 
     - name: Check platform requirements
       run: composer check-platform-reqs --verbose
-
-    - name: Run tests
-      if: matrix.phpunit == '7.*' || matrix.phpunit == '8.*'
-      run: ./vendor/bin/phpunit --coverage-text --debug --verbose
 
     - name: Run tests
       if: matrix.phpunit != '7.*' && matrix.phpunit != '8.*'

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0"
+        "php": "^7.3",
+        "phpunit/phpunit": "^9.0"
     },
     "require-dev": {
         "infection/infection": "^0.16.1",


### PR DESCRIPTION
# Changed log
- The `php-7.1` version requires `phpunit-7.x` versions at least.
It's fine to remove PHPUnit `^6.0` version.
- To support `php-7.1` version at least, define `infection/infection` to be `^0.13` version.
The `infection/infection` `^0.14` and `^0.15` versions require `php-7.2` version at least.
And the `infection/infection` `^0.16` version requires `php-7.3` version at least.